### PR TITLE
Roles using ServiceAccounts

### DIFF
--- a/deploy/crds/organization.yaml
+++ b/deploy/crds/organization.yaml
@@ -35,6 +35,10 @@ spec:
                         type: array
                         items:
                           type: string
+                      serviceAccounts:
+                        type: array
+                        items:
+                          type: string
                     required:
                       - name
                 resources:
@@ -45,7 +49,7 @@ spec:
                   properties:
                     cpu:
                       type: string
-                    memory: 
+                    memory:
                       type: string
   names:
     kind: Organization

--- a/deploy/crds/space.yaml
+++ b/deploy/crds/space.yaml
@@ -36,6 +36,10 @@ spec:
                         type: array
                         items:
                           type: string
+                      serviceAccounts:
+                        type: array
+                        items:
+                          type: string
                     required:
                       - name
                 resources:

--- a/deploy/crds/tenant.yaml
+++ b/deploy/crds/tenant.yaml
@@ -35,6 +35,10 @@ spec:
                         type: array
                         items:
                           type: string
+                      serviceAccounts:
+                        type: array
+                        items:
+                          type: string
                     required:
                       - name
                 resources:

--- a/k8spin_common/k8spin_common/resources/rbac.py
+++ b/k8spin_common/k8spin_common/resources/rbac.py
@@ -5,7 +5,8 @@ from k8spin_common.helper import kubernetes_api
 
 
 @kubernetes_api
-def create_role_binding(api, name: str, namespace: str, labels: dict, cluster_role: str, subject_kind: str, subject_name: str) -> pykube.RoleBinding:
+def create_role_binding(api, name: str, namespace: str, labels: dict, cluster_role: str, subject_kind: str, subject_name: str, subject_namespace: str) -> pykube.RoleBinding:
+    subject_last_part = f"namespace: {subject_namespace}" if subject_kind == "ServiceAccount" else "apiGroup: rbac.authorization.k8s.io"
     _obj = yaml.safe_load(
         f"""
         apiVersion: rbac.authorization.k8s.io/v1
@@ -20,7 +21,7 @@ def create_role_binding(api, name: str, namespace: str, labels: dict, cluster_ro
         subjects:
         - kind: {subject_kind}
           name: {subject_name}
-          apiGroup: rbac.authorization.k8s.io
+          {subject_last_part}
         """
         )
     metadata = _obj.get("metadata")
@@ -29,7 +30,8 @@ def create_role_binding(api, name: str, namespace: str, labels: dict, cluster_ro
 
 
 @kubernetes_api
-def create_cluster_role_binding(api, name: str, labels: dict, cluster_role: str, subject_kind: str, subject_name: str) -> pykube.ClusterRoleBinding:
+def create_cluster_role_binding(api, name: str, labels: dict, cluster_role: str, subject_kind: str, subject_name: str, subject_namespace: str) -> pykube.ClusterRoleBinding:
+    subject_last_part = f"namespace: {subject_namespace}" if subject_kind == "ServiceAccount" else "apiGroup: rbac.authorization.k8s.io"
     _obj = yaml.safe_load(
         f"""
         apiVersion: rbac.authorization.k8s.io/v1
@@ -43,9 +45,9 @@ def create_cluster_role_binding(api, name: str, labels: dict, cluster_role: str,
         subjects:
         - kind: {subject_kind}
           name: {subject_name}
-          apiGroup: rbac.authorization.k8s.io
+          {subject_last_part}
         """
         )
     metadata = _obj.get("metadata")
     metadata["labels"] = labels
-    return pykube.RoleBinding(api, _obj)
+    return pykube.ClusterRoleBinding(api, _obj)

--- a/k8spin_common/k8spin_common/resources/space.py
+++ b/k8spin_common/k8spin_common/resources/space.py
@@ -106,13 +106,13 @@ def ensure_space_role_bindings(api, organization: k8spin_common.Organization, te
                 "k8spin.cloud/space": space_name
             }
             role_binding = create_role_binding(
-                rolebinding_name, namespace.name, labels, name, target_kind, target)
+                rolebinding_name, namespace.name, labels, name, target_kind, target, None)
             ensure(role_binding, space)
             rolebindings_names.append(rolebinding_name)
             # Create required binding to allow user query namespaces
             cluster_rolebinding_name = f"{space_name}-{name}-{target_kind.lower()}-{target.lower()}"
             cluster_role_binding = create_cluster_role_binding(
-                cluster_rolebinding_name, labels, "namespace-viewer", target_kind, target)
+                cluster_rolebinding_name, labels, "namespace-viewer", target_kind, target, None)
             ensure(cluster_role_binding, space)
     # Finally, cleanup
     _clean_space_roles(organization, tenant, space, rolebindings_names)

--- a/k8spin_common/k8spin_common/resources/tenant.py
+++ b/k8spin_common/k8spin_common/resources/tenant.py
@@ -62,13 +62,13 @@ def ensure_tenant_role_bindings(api, organization: k8spin_common.Organization, t
                 "k8spin.cloud/tenant": tenant_name
             }
             role_binding = create_role_binding(
-                rolebinding_name, namespace.name, labels, name, target_kind, target)
+                rolebinding_name, namespace.name, labels, name, target_kind, target, None)
             ensure(role_binding, tenant)
             rolebindings_names.append(rolebinding_name)
             # Create required binding to allow user query namespaces
             cluster_rolebinding_name = f"{tenant_name}-{name}-{target_kind.lower()}-{target.lower()}"
             cluster_role_binding = create_cluster_role_binding(
-                cluster_rolebinding_name, labels, "namespace-viewer", target_kind, target)
+                cluster_rolebinding_name, labels, "namespace-viewer", target_kind, target, None)
             ensure(cluster_role_binding, tenant)
     # Finally, cleanup
     _clean_tenant_roles(organization, tenant, rolebindings_names)

--- a/k8spin_common/k8spin_common/resources/tenant.py
+++ b/k8spin_common/k8spin_common/resources/tenant.py
@@ -49,12 +49,17 @@ def ensure_tenant_role_bindings(api, organization: k8spin_common.Organization, t
     for role in roles:
         # Cluster role to assign
         name = role.get('name')
-        target_kind = "Group"
-        targets = role.get('groups', None)
+        target_kind = "ServiceAccount"
+        targets = role.get('serviceAccounts', None)
         if not targets:
-            target_kind = "User"
-            targets = role.get('users', list())
+            target_kind = "Group"
+            targets = role.get('groups', None)
+            if not targets:
+                target_kind = "User"
+                targets = role.get('users', list())
         for target in targets:
+            target_namespace = target.split(":")[0] if target_kind == "ServiceAccount" else None
+            target = target.split(":")[1] if target_kind == "ServiceAccount" else target
             rolebinding_name = f"{tenant_name}-{name}-{target_kind.lower()}-{target.lower()}"
             labels = {
                 "k8spin.cloud/type": "role",
@@ -62,13 +67,13 @@ def ensure_tenant_role_bindings(api, organization: k8spin_common.Organization, t
                 "k8spin.cloud/tenant": tenant_name
             }
             role_binding = create_role_binding(
-                rolebinding_name, namespace.name, labels, name, target_kind, target, None)
+                rolebinding_name, namespace.name, labels, name, target_kind, target, target_namespace)
             ensure(role_binding, tenant)
             rolebindings_names.append(rolebinding_name)
             # Create required binding to allow user query namespaces
             cluster_rolebinding_name = f"{tenant_name}-{name}-{target_kind.lower()}-{target.lower()}"
             cluster_role_binding = create_cluster_role_binding(
-                cluster_rolebinding_name, labels, "namespace-viewer", target_kind, target, None)
+                cluster_rolebinding_name, labels, "namespace-viewer", target_kind, target, target_namespace)
             ensure(cluster_role_binding, tenant)
     # Finally, cleanup
     _clean_tenant_roles(organization, tenant, rolebindings_names)

--- a/tests/e2e/test_basic.py
+++ b/tests/e2e/test_basic.py
@@ -1,17 +1,20 @@
-
-from pathlib import Path
-import time
 import inspect
+import time
+from pathlib import Path
 
-from slugify import slugify
-from pykube import Namespace, RoleBinding, ClusterRoleBinding
 import pykube
 import pytest
+from pykube import ClusterRoleBinding, Namespace, RoleBinding
+from slugify import slugify
+
+from k8spin_common.resources.organization import (
+    get_organization, organization_namespacename_generator)
+from k8spin_common.resources.space import (get_space,
+                                           space_namespacename_generator)
+from k8spin_common.resources.tenant import (get_tenant,
+                                            tenant_namespacename_generator)
 
 from .utils import create_org_object, create_space_object, create_tenant_object
-from k8spin_common.resources.organization import organization_namespacename_generator, get_organization
-from k8spin_common.resources.tenant import tenant_namespacename_generator, get_tenant
-from k8spin_common.resources.space import space_namespacename_generator, get_space
 
 TIMEOUT = 2
 ORG_NAME = "acme"
@@ -21,44 +24,55 @@ SPACE_NAME = "tunes"
 
 def test_create_org(cluster):
     test_id = "t1"
-    org = create_org_object(api=cluster.api, organization_name=test_id+ORG_NAME)
+    org = create_org_object(
+        api=cluster.api, organization_name=test_id+ORG_NAME)
     org.create()
     time.sleep(TIMEOUT)
 
-    namespace = Namespace.objects(cluster.api).get(name=organization_namespacename_generator(organization_name=test_id+ORG_NAME))
+    namespace = Namespace.objects(cluster.api).get(
+        name=organization_namespacename_generator(organization_name=test_id+ORG_NAME))
     assert namespace.labels["k8spin.cloud/type"] == "organization"
     assert namespace.labels["k8spin.cloud/org"] == test_id+ORG_NAME
 
+
 def test_create_tenant(cluster):
     test_id = "t2"
-    org = create_org_object(api=cluster.api, organization_name=test_id+ORG_NAME)
+    org = create_org_object(
+        api=cluster.api, organization_name=test_id+ORG_NAME)
     org.create()
     time.sleep(TIMEOUT)
 
-    tenant = create_tenant_object(api=cluster.api, organization_name=test_id+ORG_NAME, tenant_name=test_id+TENANT_NAME)
+    tenant = create_tenant_object(
+        api=cluster.api, organization_name=test_id+ORG_NAME, tenant_name=test_id+TENANT_NAME)
     tenant.create()
     time.sleep(TIMEOUT)
 
-    namespace = Namespace.objects(cluster.api).get(name=tenant_namespacename_generator(organization_name=test_id+ORG_NAME, tenant_name=test_id+TENANT_NAME))
+    namespace = Namespace.objects(cluster.api).get(name=tenant_namespacename_generator(
+        organization_name=test_id+ORG_NAME, tenant_name=test_id+TENANT_NAME))
     assert namespace.labels["k8spin.cloud/type"] == "tenant"
     assert namespace.labels["k8spin.cloud/org"] == test_id+ORG_NAME
     assert namespace.labels["k8spin.cloud/tenant"] == test_id+TENANT_NAME
 
+
 def test_create_spaces(cluster):
     test_id = "t3"
-    org = create_org_object(api=cluster.api, organization_name=test_id+ORG_NAME)
+    org = create_org_object(
+        api=cluster.api, organization_name=test_id+ORG_NAME)
     org.create()
     time.sleep(TIMEOUT)
 
-    tenant = create_tenant_object(api=cluster.api, organization_name=test_id+ORG_NAME, tenant_name=test_id+TENANT_NAME)
+    tenant = create_tenant_object(
+        api=cluster.api, organization_name=test_id+ORG_NAME, tenant_name=test_id+TENANT_NAME)
     tenant.create()
     time.sleep(TIMEOUT)
 
-    space = create_space_object(api=cluster.api, organization_name=test_id+ORG_NAME, tenant_name=test_id+TENANT_NAME, space_name=test_id+SPACE_NAME)
+    space = create_space_object(api=cluster.api, organization_name=test_id +
+                                ORG_NAME, tenant_name=test_id+TENANT_NAME, space_name=test_id+SPACE_NAME)
     space.create()
     time.sleep(TIMEOUT)
 
-    namespace = Namespace.objects(cluster.api).get(name=space_namespacename_generator(organization_name=test_id+ORG_NAME, tenant_name=test_id+TENANT_NAME, space_name=test_id+SPACE_NAME))
+    namespace = Namespace.objects(cluster.api).get(name=space_namespacename_generator(
+        organization_name=test_id+ORG_NAME, tenant_name=test_id+TENANT_NAME, space_name=test_id+SPACE_NAME))
     assert namespace.labels["k8spin.cloud/type"] == "space"
     assert namespace.labels["k8spin.cloud/org"] == test_id+ORG_NAME
     assert namespace.labels["k8spin.cloud/tenant"] == test_id+TENANT_NAME
@@ -74,15 +88,18 @@ def test_create_spaces(cluster):
     })
     assert len(limitRanges) == 1
 
+
 def test_manage_limits_tenant(cluster):
     test_id = "t4"
-    org = create_org_object(api=cluster.api, organization_name=test_id+ORG_NAME)
+    org = create_org_object(
+        api=cluster.api, organization_name=test_id+ORG_NAME)
     org.obj["spec"]["resources"]["cpu"] = "2"
     org.obj["spec"]["resources"]["memory"] = "2G"
     org.create()
     time.sleep(TIMEOUT)
 
-    tenant = create_tenant_object(api=cluster.api, organization_name=test_id+ORG_NAME, tenant_name=test_id+TENANT_NAME)
+    tenant = create_tenant_object(
+        api=cluster.api, organization_name=test_id+ORG_NAME, tenant_name=test_id+TENANT_NAME)
     tenant.obj["spec"]["resources"]["cpu"] = "3"
     tenant.obj["spec"]["resources"]["memory"] = "2G"
     with pytest.raises(pykube.exceptions.HTTPError, match=".*validating.tenants.k8spin.cloud.*Resources exceeded.*"):
@@ -102,15 +119,18 @@ def test_manage_limits_tenant(cluster):
     tenant.obj["spec"]["resources"]["memory"] = "2000M"
     tenant.create()
 
+
 def test_manage_limits_tenant_modorg(cluster):
     test_id = "t5"
-    org = create_org_object(api=cluster.api, organization_name=test_id+ORG_NAME)
+    org = create_org_object(
+        api=cluster.api, organization_name=test_id+ORG_NAME)
     org.obj["spec"]["resources"]["cpu"] = "2"
     org.obj["spec"]["resources"]["memory"] = "2G"
     org.create()
     time.sleep(TIMEOUT)
 
-    tenant = create_tenant_object(api=cluster.api, organization_name=test_id+ORG_NAME, tenant_name=test_id+TENANT_NAME)
+    tenant = create_tenant_object(
+        api=cluster.api, organization_name=test_id+ORG_NAME, tenant_name=test_id+TENANT_NAME)
     tenant.obj["spec"]["resources"]["cpu"] = "3"
     tenant.obj["spec"]["resources"]["memory"] = "3G"
     with pytest.raises(pykube.exceptions.HTTPError, match=".*validating.tenants.k8spin.cloud.*Resources exceeded.*"):
@@ -124,21 +144,25 @@ def test_manage_limits_tenant_modorg(cluster):
 
     tenant.create()
 
+
 def test_manage_limits_space(cluster):
     test_id = "t6"
-    org = create_org_object(api=cluster.api, organization_name=test_id+ORG_NAME)
+    org = create_org_object(
+        api=cluster.api, organization_name=test_id+ORG_NAME)
     org.obj["spec"]["resources"]["cpu"] = "10"
     org.obj["spec"]["resources"]["memory"] = "10G"
     org.create()
     time.sleep(TIMEOUT)
 
-    tenant = create_tenant_object(api=cluster.api, organization_name=test_id+ORG_NAME, tenant_name=test_id+TENANT_NAME)
+    tenant = create_tenant_object(
+        api=cluster.api, organization_name=test_id+ORG_NAME, tenant_name=test_id+TENANT_NAME)
     tenant.obj["spec"]["resources"]["cpu"] = "5"
     tenant.obj["spec"]["resources"]["memory"] = "5G"
     tenant.create()
     time.sleep(TIMEOUT)
 
-    space = create_space_object(api=cluster.api, organization_name=test_id+ORG_NAME, tenant_name=test_id+TENANT_NAME, space_name=test_id+SPACE_NAME)
+    space = create_space_object(api=cluster.api, organization_name=test_id +
+                                ORG_NAME, tenant_name=test_id+TENANT_NAME, space_name=test_id+SPACE_NAME)
     space.obj["spec"]["resources"]["cpu"] = "10"
     space.obj["spec"]["resources"]["memory"] = "10G"
     with pytest.raises(pykube.exceptions.HTTPError, match=".*validating.spaces.k8spin.cloud.*Resources exceeded.*"):
@@ -148,27 +172,32 @@ def test_manage_limits_space(cluster):
     space.obj["spec"]["resources"]["memory"] = "4G"
     space.create()
 
+
 def test_manage_limits_space_modtenant(cluster):
     test_id = "t7"
-    org = create_org_object(api=cluster.api, organization_name=test_id+ORG_NAME)
+    org = create_org_object(
+        api=cluster.api, organization_name=test_id+ORG_NAME)
     org.obj["spec"]["resources"]["cpu"] = "10"
     org.obj["spec"]["resources"]["memory"] = "10G"
     org.create()
     time.sleep(TIMEOUT)
 
-    tenant = create_tenant_object(api=cluster.api, organization_name=test_id+ORG_NAME, tenant_name=test_id+TENANT_NAME)
+    tenant = create_tenant_object(
+        api=cluster.api, organization_name=test_id+ORG_NAME, tenant_name=test_id+TENANT_NAME)
     tenant.obj["spec"]["resources"]["cpu"] = "5"
     tenant.obj["spec"]["resources"]["memory"] = "5G"
     tenant.create()
     time.sleep(TIMEOUT)
 
-    space = create_space_object(api=cluster.api, organization_name=test_id+ORG_NAME, tenant_name=test_id+TENANT_NAME, space_name=test_id+SPACE_NAME)
+    space = create_space_object(api=cluster.api, organization_name=test_id +
+                                ORG_NAME, tenant_name=test_id+TENANT_NAME, space_name=test_id+SPACE_NAME)
     space.obj["spec"]["resources"]["cpu"] = "10"
     space.obj["spec"]["resources"]["memory"] = "10G"
     with pytest.raises(pykube.exceptions.HTTPError, match=".*validating.spaces.k8spin.cloud.*Resources exceeded.*"):
         space.create()
 
-    tenant = get_tenant(organization_name=test_id+ORG_NAME, tenant_name=test_id+TENANT_NAME)
+    tenant = get_tenant(organization_name=test_id+ORG_NAME,
+                        tenant_name=test_id+TENANT_NAME)
     tenant.obj["spec"]["resources"]["cpu"] = "10"
     tenant.obj["spec"]["resources"]["memory"] = "10G"
     tenant.update()
@@ -181,7 +210,8 @@ def test_manage_limits_space_modtenant(cluster):
 
 def test_org_roles(cluster):
     test_id = "t8"
-    org = create_org_object(api=cluster.api, organization_name=test_id+ORG_NAME)
+    org = create_org_object(
+        api=cluster.api, organization_name=test_id+ORG_NAME)
     org.obj["spec"]["roles"] = [{
         "name": "organization-admin",
         "serviceAccounts": ["kube-system:default"]
@@ -201,7 +231,8 @@ def test_org_roles(cluster):
 
 def test_org_cluster_roles(cluster):
     test_id = "t9"
-    org = create_org_object(api=cluster.api, organization_name=test_id+ORG_NAME)
+    org = create_org_object(
+        api=cluster.api, organization_name=test_id+ORG_NAME)
     org.obj["spec"]["roles"] = [{
         "name": "organization-admin",
         "serviceAccounts": ["kube-system:default"]


### PR DESCRIPTION
This PR closes #3 

Now we can assign roles to serviceAccounts instead of Users and Groups.

`serviceAccounts: ["kube-system:default"]`: The value of `serviceAccounts` should be a string array. Each string in form of `namespace:service_account_name`. Same syntax used in kubectl cli: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#kubectl-create-rolebinding


```yaml
apiVersion: k8spin.cloud/v1
kind: Organization
metadata:
  name: example
spec:
  resources:
    cpu: "10"
    memory: "10G"
  # By default the organization name could be used to access the organization if the certificate include the name in the certificate filed O=
  roles:
    - name: organization-admin # Cluster Role
      groups: ["K8Spin.cloud"] # User Certificate O=
    - name: organization-admin # Cluster Role
      users: ["Angel", "Pau"] # User Certificate CN=
    - name: organization-admin # THE NEW ONE
      serviceAccounts: ["kube-system:default"] # THE NEW ONE
```

I've added a couple of e2e tests to verify it