### PR TITLE
Uniform image name across deployments

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -15,11 +15,5 @@ serialize =
 
 [bumpversion:file:deployments/helm/k8spin-operator/values.yaml]
 
-[bumpversion:file:deployments/kubernetes/operator.yaml]
-
-[bumpversion:file:deployments/kubernetes/webhook.yaml]
-
-[bumpversion:file:test/e2e/conftest.py]
-
 [bumpversion:file:kubectl-k8spin.py]
 

--- a/Makefile
+++ b/Makefile
@@ -26,15 +26,15 @@ cluster-down:
 
 ## build: Local build the operator
 build:
-	@docker build -t k8spin/k8spin-operator:dev -t k8spin/k8spin-operator:latest -t k8spin/k8spin-operator:$(TAG_VERSION) . -f build/operator.Dockerfile
-	@docker build -t k8spin/k8spin-webhook:dev -t k8spin/k8spin-webhook:latest -t k8spin/k8spin-webhook:$(TAG_VERSION) . -f build/webhook.Dockerfile
+	@docker build -t $(REGISTRY)/k8spin/k8spin-operator:latest -t $(REGISTRY)/k8spin/k8spin-operator:$(TAG_VERSION) . -f build/operator.Dockerfile
+	@docker build -t $(REGISTRY)/k8spin/k8spin-webhook:latest -t $(REGISTRY)/k8spin/k8spin-webhook:$(TAG_VERSION) . -f build/webhook.Dockerfile
 
 ## build: Local build the operator using buildx and multiple platforms
 ## platforms defined in https://github.com/containerd/containerd/blob/v1.2.6/platforms/platforms.go#L63
 ## docker > 19.03 required
 buildx:
-	@DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --platform=linux/amd64,linux/arm64,linux/arm/v7  -t k8spin/k8spin-operator:dev . -f build/operator.Dockerfile
-	@DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --platform=linux/amd64,linux/arm64,linux/arm/v7 -t k8spin/k8spin-webhook:dev . -f build/webhook.Dockerfile
+	@DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --platform=linux/amd64,linux/arm64,linux/arm/v7 -t $(REGISTRY)/k8spin/k8spin-operator:latest -t $(REGISTRY)/k8spin/k8spin-operator:$(TAG_VERSION) . -f build/operator.Dockerfile
+	@DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --platform=linux/amd64,linux/arm64,linux/arm/v7 -t $(REGISTRY)/k8spin/k8spin-webhook:latest -t $(REGISTRY)/k8spin/k8spin-webhook:$(TAG_VERSION) . -f build/webhook.Dockerfile
 
 ## deploy: Deploys the complete solution
 deploy: load
@@ -67,22 +67,22 @@ test-kubeconfig:
 	@export KUBECONFIG=.pytest-kind/k8spin-operator/kind-config-k8spin-operator
 
 load: cluster-up build
-	@kind load docker-image --name $(KIND_CLUSTER_NAME) k8spin/k8spin-operator:$(TAG_VERSION)
-	@kind load docker-image --name $(KIND_CLUSTER_NAME) k8spin/k8spin-webhook:$(TAG_VERSION)
+	@kind load docker-image --name $(KIND_CLUSTER_NAME) $(REGISTRY)/k8spin/k8spin-operator:latest
+	@kind load docker-image --name $(KIND_CLUSTER_NAME) $(REGISTRY)/k8spin/k8spin-webhook:latest
 
 ## kubie: Sets the kind cluster context
 kubie:
 	@kubie ctx kind-$(KIND_CLUSTER_NAME)
 
 publish_container_image:
-	@docker tag k8spin/k8spin-operator:$(TAG_VERSION) $(REGISTRY)/k8spin/k8spin-operator:$(TAG_VERSION)
-	@docker tag k8spin/k8spin-webhook:$(TAG_VERSION) $(REGISTRY)/k8spin/k8spin-webhook:$(TAG_VERSION)
+	@docker tag $(REGISTRY)/k8spin/k8spin-operator:latest $(REGISTRY)/k8spin/k8spin-operator:$(TAG_VERSION)
+	@docker tag $(REGISTRY)/k8spin/k8spin-webhook:latest $(REGISTRY)/k8spin/k8spin-webhook:$(TAG_VERSION)
 	@docker push $(REGISTRY)/k8spin/k8spin-operator:$(TAG_VERSION)
 	@docker push $(REGISTRY)/k8spin/k8spin-webhook:$(TAG_VERSION)
 
 
 publish_container_image_multiarch:
-	@DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --platform=linux/amd64,linux/arm64,linux/arm/v7  -t $(REGISTRY)/k8spin/k8spin-operator:$(TAG_VERSION) . -f build/operator.Dockerfile --push
+	@DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --platform=linux/amd64,linux/arm64,linux/arm/v7 -t $(REGISTRY)/k8spin/k8spin-operator:$(TAG_VERSION) . -f build/operator.Dockerfile --push
 	@DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --platform=linux/amd64,linux/arm64,linux/arm/v7 -t $(REGISTRY)/k8spin/k8spin-webhook:$(TAG_VERSION) . -f build/webhook.Dockerfile --push
 
 ## clean: Remove cached files

--- a/deployments/kubernetes/operator.yaml
+++ b/deployments/kubernetes/operator.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: k8spin-operator
       containers:
       - name: k8spin-operator
-        image: k8spin/k8spin-operator:v1.0.4
+        image: ghcr.io/k8spin/k8spin-operator:latest
         env:
         - name: LOGGING_LEVEL
           value: DEBUG

--- a/deployments/kubernetes/webhook.yaml
+++ b/deployments/kubernetes/webhook.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: k8spin-webhook
       containers:
       - name: k8spin-webhook
-        image: k8spin/k8spin-webhook:v1.0.4
+        image: ghcr.io/k8spin/k8spin-webhook:latest
         ports:
         - containerPort: 443
         env:

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -14,10 +14,10 @@ kind_cluster_name = "k8spin-operator-e2e"
 def cluster(kind_cluster) -> Generator[dict, None, None]:
     kubectl = kind_cluster.kubectl
 
-    operator_image = "k8spin/k8spin-operator:v1.0.4"
+    operator_image = "ghcr.io/k8spin/k8spin-operator:latest"
     kind_cluster.load_docker_image(operator_image)
 
-    webhook_image = "k8spin/k8spin-webhook:v1.0.4"
+    webhook_image = "ghcr.io/k8spin/k8spin-webhook:latest"
     kind_cluster.load_docker_image(webhook_image)
 
     logging.info("Deploying Calico")


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bugfix, feature, docs update, ...)
It improves the usability of the Kubernetes deployment. Suggested in #31 

### What is the current behavior? (You can also link to an open issue here)
Currently, if you deploy the "plain" kubernetes manifest, it does not work because of the image is not published in dockerhub.
We maintain it because of e2e tests.

### What is the new behavior (if this is a feature change)?
Now you can deploy k8spin operator both using the helm chart and the plain kubernetes manifests without any modification.
e2e tests has been modified to use the right container image name.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
N/A

### Other information:

e2e testing pipeline: https://github.com/k8spin/k8spin-operator/runs/1299412572?check_suite_focus=true

Thanks to @isnuryusuf for spotting this miss-configuration.
