### PR TITLE
Enforcing runtimeClassName

### DIFF
--- a/deployments/helm/k8spin-operator/crds/space.yaml
+++ b/deployments/helm/k8spin-operator/crds/space.yaml
@@ -72,6 +72,11 @@ spec:
                               type: string
                             memory:
                               type: string
+                    enforcing:
+                      type: object
+                      properties:
+                        runtimeClassName:
+                            type: string
                 allowIncomingNetwork:
                   type: object
                   properties:

--- a/deployments/helm/k8spin-operator/crds/space.yaml
+++ b/deployments/helm/k8spin-operator/crds/space.yaml
@@ -72,7 +72,7 @@ spec:
                               type: string
                             memory:
                               type: string
-                    enforcing:
+                    enforce:
                       type: object
                       properties:
                         runtimeClassName:

--- a/deployments/kubernetes/crds/space.yaml
+++ b/deployments/kubernetes/crds/space.yaml
@@ -72,6 +72,11 @@ spec:
                               type: string
                             memory:
                               type: string
+                    enforcing:
+                      type: object
+                      properties:
+                        runtimeClassName:
+                            type: string
                 allowIncomingNetwork:
                   type: object
                   properties:

--- a/deployments/kubernetes/crds/space.yaml
+++ b/deployments/kubernetes/crds/space.yaml
@@ -72,7 +72,7 @@ spec:
                               type: string
                             memory:
                               type: string
-                    enforcing:
+                    enforce:
                       type: object
                       properties:
                         runtimeClassName:

--- a/deployments/kubernetes/operator.yaml
+++ b/deployments/kubernetes/operator.yaml
@@ -20,6 +20,7 @@ spec:
       containers:
       - name: k8spin-operator
         image: ghcr.io/k8spin/k8spin-operator:latest
+        imagePullPolicy: IfNotPresent
         env:
         - name: LOGGING_LEVEL
           value: DEBUG

--- a/deployments/kubernetes/webhook.yaml
+++ b/deployments/kubernetes/webhook.yaml
@@ -207,3 +207,23 @@ webhooks:
         operations:
           - CREATE
           - UPDATE
+  - name: mutating.pods.k8spin.cloud
+    failurePolicy: Fail
+    objectSelector:
+      matchExpressions:
+        - {key: application, operator: NotIn, values: [k8spin-webhook, k8spin-operator]}
+    clientConfig:
+      service:
+        name: k8spin-webhook
+        namespace: default
+        path: /mutator/pods
+      caBundle: Cg==
+    rules:
+      - apiGroups: [""]
+        resources:
+          - "pods"
+        apiVersions:
+          - "v1"
+        operations:
+          - CREATE
+          - UPDATE

--- a/deployments/kubernetes/webhook.yaml
+++ b/deployments/kubernetes/webhook.yaml
@@ -20,6 +20,7 @@ spec:
       containers:
       - name: k8spin-webhook
         image: ghcr.io/k8spin/k8spin-webhook:latest
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 443
         env:

--- a/k8spin_common/k8spin_common/__init__.py
+++ b/k8spin_common/k8spin_common/__init__.py
@@ -118,4 +118,4 @@ class Space(NamespacedAPIObject):
 
     @property
     def runtime(self) -> str:
-        return self.obj["spec"]["containers"].get("enforcing", {}).get("runtimeClassName")
+        return self.obj["spec"]["containers"].get("enforce", {}).get("runtimeClassName")

--- a/k8spin_common/k8spin_common/__init__.py
+++ b/k8spin_common/k8spin_common/__init__.py
@@ -115,3 +115,7 @@ class Space(NamespacedAPIObject):
     @property
     def get_allow_incoming_network(self) -> list:
         return self.obj["spec"].get("allowIncomingNetwork", {})
+
+    @property
+    def runtime(self) -> str:
+        return self.obj["spec"]["containers"].get("enforcing", {}).get("runtimeClassName")


### PR DESCRIPTION
Added "spec.containers.enforcing.runtimeClassName" in Space object. 
Setting this property will ensure the given runtimeClassName is used to run all the pods in the Space.

This PR solves https://github.com/k8spin/k8spin-operator/issues/10. 


