### PR TITLE
Fixing k8s 1.20 compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL:=/bin/bash
 
 PROJECTNAME=$(shell basename "$(PWD)")
-CLUSTER_VERSION="1.18.8"
+CLUSTER_VERSION="1.20.2"
 KIND_CLUSTER_NAME="k8spin-operator"
 PYTEST_PARAMS=""
 TAG_VERSION="v1.1.0"
@@ -49,7 +49,7 @@ update: load
 
 ## test-e2e: End-to-End tests. Use `PYTEST_ADDOPTS=--keep-cluster make test-e2e` to keep cluster --workers auto could be added when we want multiple workers installing the package pytest-parallel
 test-e2e: build
-	@virtualenv -p python3.8 .venv-test
+	@virtualenv -p python3.9 .venv-test
 	source .venv-test/bin/activate; \
 	pip install -r test/requirements.txt; \
 	pip install -e k8spin_common; \
@@ -101,7 +101,7 @@ lint:
 
 ## helm_chart_docs: Creates the Helm Chart Docs
 helm_chart_docs:
-	@virtualenv -p python3.8 .venv-chart-docs
+	@virtualenv -p python3.9 .venv-chart-docs
 	source .venv-chart-docs/bin/activate; \
 	pip install frigate; \
 	frigate gen deployments/helm/k8spin-operator > deployments/helm/k8spin-operator/README.md;

--- a/deployments/helm/k8spin-operator/README.md
+++ b/deployments/helm/k8spin-operator/README.md
@@ -11,17 +11,17 @@ The following table lists the configurable parameters of the K8spin-operator cha
 
 | Parameter                | Description             | Default        |
 | ------------------------ | ----------------------- | -------------- |
-| `k8spin_operator.image.name` | K8spin-operator image name | `"ghcr.io/k8spin/k8spin-operator"` |
-| `k8spin_operator.image.tag` | K8spin-operator image tag | `"v1.0.6"` |
-| `k8spin_operator.image.pullPolicy` | K8spin-operator image pull policy | `"IfNotPresent"` |
-| `k8spin_operator.logging_level` | K8spin-operator logging level | `"DEBUG"` |
-| `k8spin_operator.reconciliation_interval_seconds` | K8spin-operator reconciliation interval in seconds | `"15"` |
+| `k8spin_operator.image.name` | k8spin-operator image name | `"ghcr.io/k8spin/k8spin-operator"` |
+| `k8spin_operator.image.tag` | k8spin-operator image tag | `"v1.1.0"` |
+| `k8spin_operator.image.pullPolicy` | k8spin-operator image pull policy | `"IfNotPresent"` |
+| `k8spin_operator.logging_level` | k8spin-operator logging level | `"DEBUG"` |
+| `k8spin_operator.reconciliation_interval_seconds` | k8spin-operator reconciliation interval in seconds | `"15"` |
 | `k8spin_operator.serviceAccount.create` | Create the k8spin-operator service account | `true` |
 | `k8spin_operator.serviceAccount.name` | The k8spin-operator service account name | `null` |
-| `k8spin_webhook.image.name` | K8spin-webhook image name | `"ghcr.io/k8spin/k8spin-webhook"` |
-| `k8spin_webhook.image.tag` | K8spin-webhook image tag | `"v1.0.6"` |
-| `k8spin_webhook.image.pullPolicy` | K8spin-webhook image pull policy | `"IfNotPresent"` |
-| `k8spin_webhook.logging_level` | K8spin-webhook logging level | `"DEBUG"` |
+| `k8spin_webhook.image.name` | k8spin-webhook image name | `"ghcr.io/k8spin/k8spin-webhook"` |
+| `k8spin_webhook.image.tag` | k8spin-webhook image tag | `"v1.1.0"` |
+| `k8spin_webhook.image.pullPolicy` | k8spin-webhook image pull policy | `"IfNotPresent"` |
+| `k8spin_webhook.logging_level` | k8spin-webhook logging level | `"DEBUG"` |
 | `k8spin_webhook.serviceAccount.create` | Create the k8spin-webhook service account | `true` |
 | `k8spin_webhook.serviceAccount.name` | The k8spin-webhook service account name | `null` |
 | `rbac.create` | Deploys default roles | `true` |

--- a/deployments/helm/k8spin-operator/templates/k8spin-webhook.yaml
+++ b/deployments/helm/k8spin-operator/templates/k8spin-webhook.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
@@ -13,6 +13,9 @@ metadata:
 webhooks:
   - name: validating.tenants.k8spin.cloud
     failurePolicy: Fail
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    timeoutSeconds: 5
     clientConfig:
       service:
         name: k8spin-webhook
@@ -30,6 +33,9 @@ webhooks:
           - UPDATE
   - name: validating.spaces.k8spin.cloud
     failurePolicy: Fail
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    timeoutSeconds: 5
     clientConfig:
       service:
         name: k8spin-webhook
@@ -46,7 +52,7 @@ webhooks:
           - CREATE
           - UPDATE
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
@@ -61,6 +67,9 @@ metadata:
 webhooks:
   - name: mutating.organizations.k8spin.cloud
     failurePolicy: Fail
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    timeoutSeconds: 5
     clientConfig:
       service:
         name: k8spin-webhook
@@ -78,6 +87,9 @@ webhooks:
           - UPDATE
   - name: mutating.tenants.k8spin.cloud
     failurePolicy: Fail
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    timeoutSeconds: 5
     clientConfig:
       service:
         name: k8spin-webhook
@@ -95,6 +107,9 @@ webhooks:
           - UPDATE
   - name: mutating.spaces.k8spin.cloud
     failurePolicy: Fail
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    timeoutSeconds: 5
     clientConfig:
       service:
         name: k8spin-webhook
@@ -105,6 +120,29 @@ webhooks:
       - apiGroups: ["k8spin.cloud"]
         resources:
           - "spaces"
+        apiVersions:
+          - "v1"
+        operations:
+          - CREATE
+          - UPDATE
+  - name: mutating.pods.k8spin.cloud
+    failurePolicy: Fail
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    timeoutSeconds: 5
+    objectSelector:
+      matchExpressions:
+        - {key: application, operator: NotIn, values: [k8spin-webhook, k8spin-operator]}
+    clientConfig:
+      service:
+        name: k8spin-webhook
+        namespace: {{ .Release.Namespace }}
+        path: /mutator/pods
+      caBundle: Cg==
+    rules:
+      - apiGroups: [""]
+        resources:
+          - "pods"
         apiVersions:
           - "v1"
         operations:

--- a/deployments/kubernetes/webhook.yaml
+++ b/deployments/kubernetes/webhook.yaml
@@ -106,7 +106,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   annotations:
@@ -116,6 +116,9 @@ metadata:
 webhooks:
   - name: validating.tenants.k8spin.cloud
     failurePolicy: Fail
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    timeoutSeconds: 5
     clientConfig:
       service:
         name: k8spin-webhook
@@ -133,6 +136,9 @@ webhooks:
           - UPDATE
   - name: validating.spaces.k8spin.cloud
     failurePolicy: Fail
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    timeoutSeconds: 5
     clientConfig:
       service:
         name: k8spin-webhook
@@ -149,7 +155,7 @@ webhooks:
           - CREATE
           - UPDATE
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
@@ -159,6 +165,9 @@ metadata:
 webhooks:
   - name: mutating.organizations.k8spin.cloud
     failurePolicy: Fail
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    timeoutSeconds: 5
     clientConfig:
       service:
         name: k8spin-webhook
@@ -176,6 +185,9 @@ webhooks:
           - UPDATE
   - name: mutating.tenants.k8spin.cloud
     failurePolicy: Fail
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    timeoutSeconds: 5
     clientConfig:
       service:
         name: k8spin-webhook
@@ -193,6 +205,9 @@ webhooks:
           - UPDATE
   - name: mutating.spaces.k8spin.cloud
     failurePolicy: Fail
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    timeoutSeconds: 5
     clientConfig:
       service:
         name: k8spin-webhook
@@ -210,6 +225,9 @@ webhooks:
           - UPDATE
   - name: mutating.pods.k8spin.cloud
     failurePolicy: Fail
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    timeoutSeconds: 5
     objectSelector:
       matchExpressions:
         - {key: application, operator: NotIn, values: [k8spin-webhook, k8spin-operator]}

--- a/k8spin_common/Makefile
+++ b/k8spin_common/Makefile
@@ -13,7 +13,7 @@ help: Makefile
 
 ## install: Install the project
 install:
-	@virtualenv -p python3.8 .venv
+	@virtualenv -p python3.9 .venv
 	source .venv/bin/activate; \
 	pip install -r requirements-dev.txt; \
 

--- a/k8spin_common/k8spin_common/__init__.py
+++ b/k8spin_common/k8spin_common/__init__.py
@@ -48,11 +48,16 @@ class Tenant(NamespacedAPIObject):
     @property
     def tenant_namespace(self) -> Namespace:
         namespaces = Namespace.objects(self.api).filter(
-            selector={"k8spin.cloud/org": self.org.name, "k8spin.cloud/type": "tenant"})
+            selector={
+                "k8spin.cloud/org": self.org.name,
+                "k8spin.cloud/tenant": self.name,
+                "k8spin.cloud/type": "tenant"
+            })
+        matched_ns = list()
         for namespace in namespaces:
-            if any([owner.get("name") == self.name
-                    for owner in namespace.metadata.get("ownerReferences", list())]):
-                return namespace
+            matched_ns.append(namespace)
+        if len(matched_ns) == 1:
+            return matched_ns[0]
         # TODO CHANGE WITH K8SPIN EXCEPTIONS
         raise Exception("Tenant namespace not found")
 
@@ -92,11 +97,13 @@ class Space(NamespacedAPIObject):
         namespaces = Namespace.objects(self.api).filter(
             selector={"k8spin.cloud/org": self.org.name,
                       "k8spin.cloud/tenant": self.tenant.name,
+                      "k8spin.cloud/space": self.name,
                       "k8spin.cloud/type": "space"})
+        matched_ns = list()
         for namespace in namespaces:
-            if any([owner.get("name") == self.name
-                    for owner in namespace.metadata.get("ownerReferences", list())]):
-                return namespace
+            matched_ns.append(namespace)
+        if len(matched_ns) == 1:
+            return matched_ns[0]
         # TODO CHANGE WITH K8SPIN EXCEPTIONS
         raise Exception("Space namespace not found")
 

--- a/k8spin_common/k8spin_common/helper.py
+++ b/k8spin_common/k8spin_common/helper.py
@@ -40,7 +40,8 @@ def _get_kube_api():
 
 def ensure(resource: APIObject, owner: APIObject):
     if not resource.exists():
-        resource = adopt(owner, resource)
+        if owner.namespace == resource.namespace:
+            resource = adopt(owner, resource)
         resource.create()
     else:
         resource.update()

--- a/k8spin_common/k8spin_common/resources/space.py
+++ b/k8spin_common/k8spin_common/resources/space.py
@@ -1,11 +1,10 @@
-import pykube
-
 import k8spin_common
+import pykube
 from k8spin_common.helper import adopt, ensure, kubernetes_api
 from k8spin_common.resources.namespace import create_namespace
+from k8spin_common.resources.network_policies import create_network_policy
 from k8spin_common.resources.quotas import (create_limit_range,
                                             create_resource_quota)
-from k8spin_common.resources.network_policies import create_network_policy
 from k8spin_common.resources.rbac import (create_cluster_role_binding,
                                           create_role_binding)
 from k8spin_common.resources.tenant import tenant_namespacename_generator

--- a/k8spin_common/k8spin_common/resources/space.py
+++ b/k8spin_common/k8spin_common/resources/space.py
@@ -31,6 +31,7 @@ def ensure_space_resources(organization: k8spin_common.Organization, tenant: k8s
     ensure_space_network_policies(
         organization=organization, tenant=tenant, space_name=space_name)
 
+
 @kubernetes_api
 def ensure_space_namespace(api, organization: k8spin_common.Organization, tenant: k8spin_common.Tenant, space_name: str):
     space_namespace_name = space_namespacename_generator(
@@ -83,6 +84,7 @@ def ensure_space_limit_range(api, organization: k8spin_common.Organization, tena
     space_limit_range = ensure(space_limit_range, space)
     return space_limit_range
 
+
 @kubernetes_api
 def ensure_space_network_policies(api, organization: k8spin_common.Organization, tenant: k8spin_common.Tenant, space_name: str):
     space = get_space(space_name, tenant.name, organization.name)
@@ -98,6 +100,7 @@ def ensure_space_network_policies(api, organization: k8spin_common.Organization,
         "defaults", space_namespace.name, labels, allow_incoming_network)
     space_network_policy = ensure(space_network_policy, space)
     return space_network_policy
+
 
 @kubernetes_api
 def ensure_space_role_bindings(api, organization: k8spin_common.Organization, tenant: k8spin_common.Tenant, space_name: str):
@@ -119,8 +122,10 @@ def ensure_space_role_bindings(api, organization: k8spin_common.Organization, te
                 target_kind = "User"
                 targets = role.get('users', list())
         for target in targets:
-            target_namespace = target.split(":")[0] if target_kind == "ServiceAccount" else None
-            target = target.split(":")[1] if target_kind == "ServiceAccount" else target
+            target_namespace = target.split(
+                ":")[0] if target_kind == "ServiceAccount" else None
+            target = target.split(
+                ":")[1] if target_kind == "ServiceAccount" else target
             rolebinding_name = f"{space_name}-{name}-{target_kind.lower()}-{target.lower()}"
             labels = {
                 "k8spin.cloud/type": "role",

--- a/k8spin_operator/Makefile
+++ b/k8spin_operator/Makefile
@@ -13,7 +13,7 @@ help: Makefile
 
 ## install: Install the project
 install:
-	@virtualenv -p python3.8 .venv
+	@virtualenv -p python3.9 .venv
 	source .venv/bin/activate; \
 	pip install -r requirements-dev.txt; \
 	pip install -e ../k8spin_common; \

--- a/k8spin_operator/k8spin_operator/handlers/organization.py
+++ b/k8spin_operator/k8spin_operator/handlers/organization.py
@@ -1,9 +1,27 @@
 import kopf
-
 from k8spin_common.resources import organization
+from pykube.exceptions import ObjectDoesNotExist
 
 
 @kopf.on.create("k8spin.cloud", "v1", "organizations")
 @kopf.on.update("k8spin.cloud", "v1", "organizations")
 def create_organization(name, **kwargs):  # pylint: disable=W0613
     organization.ensure_organization_resources(organization_name=name)
+
+
+@kopf.on.delete("k8spin.cloud", "v1", "organizations")
+def delete_organization(name, **kwargs):  # pylint: disable=W0613
+    try:
+        org = organization.get_organization(name)  # pylint: disable=E1120
+        tenants = org.tenants
+        for tenant in tenants:
+            spaces = tenant.spaces
+            for space in spaces:
+                space_namespace = space.space_namespace
+                space_namespace.delete()
+            tenant_namespace = tenant.tenant_namespace
+            tenant_namespace.delete()
+        organization_namespace = org.organization_namespace
+        organization_namespace.delete()
+    except ObjectDoesNotExist:
+        pass

--- a/k8spin_operator/k8spin_operator/handlers/reconcile.py
+++ b/k8spin_operator/k8spin_operator/handlers/reconcile.py
@@ -6,14 +6,6 @@ from k8spin_common.resources import organization, space, tenant
 RECONCILIATION_INTERVAL = int(getenv("RECONCILIATION_INTERVAL_SECONDS", "10"))
 
 
-@kopf.on.delete("k8spin.cloud", "v1", "organizations")
-def delete():
-    # Needed to fix a problem in the bellow reconciler.
-    # Seems like reconciler does not remove the object from its cache if its not
-    # explicitly declared this deletion handler.
-    pass
-
-
 @kopf.timer("k8spin.cloud", "v1", "organizations", interval=RECONCILIATION_INTERVAL, idle=10)
 def reconciler(name, **kwargs):  # pylint: disable=W0613
     organization.ensure_organization_resources(organization_name=name)

--- a/k8spin_operator/k8spin_operator/handlers/space.py
+++ b/k8spin_operator/k8spin_operator/handlers/space.py
@@ -1,17 +1,15 @@
 import kopf
 import pykube
-
 from k8spin_common.helper import kubernetes_api
 from k8spin_common.resources import space, tenant
+from pykube.exceptions import ObjectDoesNotExist
 
 
 @kubernetes_api
 def lives_in_tenant_namespace(api, namespace, **_):
     parent_namespace = pykube.Namespace.objects(api).get(name=namespace)
     # pylint: disable=E1120
-    if parent_namespace.labels.get("k8spin.cloud/type", "") == "tenant" and any(
-            [owner.get('kind') == 'Tenant'
-             for owner in parent_namespace.metadata.get('ownerReferences', list())]):
+    if parent_namespace.labels.get("k8spin.cloud/type", "") == "tenant":
         return True
     return False
 
@@ -25,3 +23,15 @@ def create_space(name, namespace, **kwargs):  # pylint: disable=W0613
     parent_organization = parent_tenant.org
     space.ensure_space_resources(
         organization=parent_organization, tenant=parent_tenant, space_name=name)
+
+
+@kopf.on.delete("k8spin.cloud", "v1", "spaces")
+def delete_space(name, meta, **kwargs):  # pylint: disable=W0613
+    try:
+        # pylint: disable=E1120
+        tenant_space = space.get_space(name, meta.labels.get(
+            "k8spin.cloud/tenant", None), meta.labels.get("k8spin.cloud/org", None))
+        space_namespace = tenant_space.space_namespace
+        space_namespace.delete()
+    except ObjectDoesNotExist:
+        pass

--- a/k8spin_operator/k8spin_operator/handlers/tenant.py
+++ b/k8spin_operator/k8spin_operator/handlers/tenant.py
@@ -1,17 +1,15 @@
 import kopf
 import pykube
-
 from k8spin_common.helper import kubernetes_api
 from k8spin_common.resources import organization, tenant
+from pykube.exceptions import ObjectDoesNotExist
 
 
 @kubernetes_api
 def lives_in_org_namespace(api, namespace, **_):
     parent_namespace = pykube.Namespace.objects(api).get(name=namespace)
     # pylint: disable=E1120
-    if parent_namespace.labels.get("k8spin.cloud/type", "") == "organization" and any(
-            [owner.get('kind') == 'Organization'
-                for owner in parent_namespace.metadata.get('ownerReferences', list())]):
+    if parent_namespace.labels.get("k8spin.cloud/type", "") == "organization":
         return True
     return False
 
@@ -24,3 +22,19 @@ def create_tenant(name, meta, **kwargs):  # pylint: disable=W0613
         organization_name=meta.labels.get("k8spin.cloud/org", None))
     tenant.ensure_tenant_resources(
         organization=parent_organization, tenant_name=name)
+
+
+@kopf.on.delete("k8spin.cloud", "v1", "tenants")
+def delete_tenant(name, meta, **kwargs):  # pylint: disable=W0613
+    try:
+        # pylint: disable=E1120
+        org_tenant = tenant.get_tenant(
+            name, meta.labels.get("k8spin.cloud/org", None))
+        spaces = org_tenant.spaces
+        for space in spaces:
+            space_namespace = space.space_namespace
+            space_namespace.delete()
+        tenant_namespace = org_tenant.tenant_namespace
+        tenant_namespace.delete()
+    except ObjectDoesNotExist:
+        pass

--- a/k8spin_operator/requirements.txt
+++ b/k8spin_operator/requirements.txt
@@ -1,1 +1,2 @@
-kopf==0.28.3
+kopf==1.30.3
+pykube-ng

--- a/k8spin_webhook/Makefile
+++ b/k8spin_webhook/Makefile
@@ -13,7 +13,7 @@ help: Makefile
 
 ## install: Install the project
 install:
-	@virtualenv -p python3.8 .venv
+	@virtualenv -p python3.9 .venv
 	source .venv/bin/activate; \
 	pip install -r requirements-dev.txt; \
 	pip install -e ../k8spin_common; \

--- a/k8spin_webhook/app.py
+++ b/k8spin_webhook/app.py
@@ -1,7 +1,7 @@
 import logging
 from os import getenv
 
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
 from healthcheck import HealthCheck
 from pykube.exceptions import ObjectDoesNotExist
 
@@ -21,8 +21,15 @@ app.register_blueprint(mutator.blueprint)
 
 @app.errorhandler(ObjectDoesNotExist)
 def object_does_not_exist(error):
-    logger.warning('Not found error: %s. Pass', error)
-    return jsonify({"response": {"allowed": True}})
+    request_info = request.get_json()
+    msg = f"Not found @ Kubernetes error: {error}. Passing"
+    logger.warning(msg)
+    return jsonify({"apiVersion": "admission.k8s.io/v1",
+                    "kind": "AdmissionReview",
+                    "response": {"uid": request_info["request"]["uid"],
+                                 "allowed": True,
+                                 "status": {"message": msg}
+                                 }})
 
 
 if __name__ == '__main__':

--- a/k8spin_webhook/app.py
+++ b/k8spin_webhook/app.py
@@ -1,8 +1,9 @@
 import logging
 from os import getenv
 
-from flask import Flask
+from flask import Flask, jsonify
 from healthcheck import HealthCheck
+from pykube.exceptions import ObjectDoesNotExist
 
 import mutator  # pylint: disable=E0401
 import validator  # pylint: disable=E0401
@@ -16,6 +17,13 @@ health = HealthCheck(app, "/health")
 
 app.register_blueprint(validator.blueprint)
 app.register_blueprint(mutator.blueprint)
+
+
+@app.errorhandler(ObjectDoesNotExist)
+def object_does_not_exist(error):
+    logger.warning('Not found error: %s. Pass', error)
+    return jsonify({"response": {"allowed": True}})
+
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=443,

--- a/k8spin_webhook/mutator/__init__.py
+++ b/k8spin_webhook/mutator/__init__.py
@@ -2,7 +2,7 @@ import base64
 
 import jsonpatch
 from flask import Blueprint, jsonify, request
-from k8spin_common.resources import tenant, space
+from k8spin_common.resources import space, tenant
 from loguru import logger
 
 blueprint = Blueprint("mutator", __name__, url_prefix="/mutator")
@@ -66,6 +66,7 @@ def space_mutator():
 def pod_mutator():
     request_info = request.get_json()
     try:
+        # pylint: disable=E1120
         parent_space = space.get_space_from_namespace(
             space_namespace_name=request_info["request"]["namespace"])
     except KeyError: # Not a k8spin managed namespace
@@ -77,5 +78,4 @@ def pod_mutator():
                                     "value": parent_space.runtime
                                     }])
         return mutator_response(True, "", patch)
-    else:
-        return jsonify({"response": {"allowed": True}})
+    return jsonify({"response": {"allowed": True}})

--- a/k8spin_webhook/validator/__init__.py
+++ b/k8spin_webhook/validator/__init__.py
@@ -6,8 +6,17 @@ from .validator_utils import (check_space_quotas,  # pylint: disable=E0401
 blueprint = Blueprint("validator", __name__, url_prefix="/validator")
 
 
-def validator_response(allowed, message):
-    return jsonify({"response": {"allowed": allowed, "status": {"message": message}}})
+def validator_response(uid, allowed, message):
+    return jsonify({"apiVersion": "admission.k8s.io/v1",
+                    "kind": "AdmissionReview",
+                    "response":
+                        {
+                            "uid": uid,
+                            "allowed": allowed,
+                            "status": {"message": message}
+                        }
+                    }
+                   )
 
 
 @blueprint.route('/tenants', methods=['POST'])
@@ -15,7 +24,7 @@ def tenant_validator():
     request_info = request.get_json()
     resource_object = request_info["request"]["object"]
     response, message = check_tenant_quotas(resource_object)
-    return validator_response(response, message)
+    return validator_response(request_info["request"]["uid"], response, message)
 
 
 @blueprint.route('/spaces', methods=['POST'])
@@ -23,4 +32,4 @@ def space_validator():
     request_info = request.get_json()
     resource_object = request_info["request"]["object"]
     response, message = check_space_quotas(resource_object)
-    return validator_response(response, message)
+    return validator_response(request_info["request"]["uid"], response, message)


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bugfix, feature, docs update, ...)
It adds compatibility to 1.20 fixing some minor issues. 

### What is the current behaviour? (You can also link to an open issue here)
Currently, K8Spin does not work in 1.20 because of: 
- `https://github.com/kubernetes/kubernetes/issues/65200`
- `https://github.com/strimzi/strimzi-kafka-operator/pull/4080/files#`
- `https://github.com/kubernetes/kubernetes/pull/92743`


### What is the new behaviour (if this is a feature change)?
Now we don't use cross-namespace owner reference.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
-
