### PR TITLE
Update rbac.authorization.k8s.io/v1beta1 to v1

### DIFF
--- a/deployments/helm/k8spin-operator/templates/k8spin_operator_cluster_role_binding.yaml
+++ b/deployments/helm/k8spin-operator/templates/k8spin_operator_cluster_role_binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: k8spin-operator

--- a/deployments/helm/k8spin-operator/templates/k8spin_webhook_cluster_role_binding.yaml
+++ b/deployments/helm/k8spin-operator/templates/k8spin_webhook_cluster_role_binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: k8spin-webhook

--- a/deployments/kubernetes/operator.yaml
+++ b/deployments/kubernetes/operator.yaml
@@ -33,7 +33,7 @@ metadata:
   name: k8spin-operator
   namespace: default
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: k8spin-operator

--- a/deployments/kubernetes/webhook.yaml
+++ b/deployments/kubernetes/webhook.yaml
@@ -71,7 +71,7 @@ metadata:
   name: k8spin-webhook
   namespace: default
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: k8spin-webhook


### PR DESCRIPTION
IMHO this software is progressive and should provide edge k8s version support - rbac.authorization.k8s.io is out of beta to v1